### PR TITLE
Fix deprecation errors

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2145,8 +2145,7 @@ void MainWindow::on_actionReset_triggered()
   msgBox.setInformativeText(tr("Are you sure?"));
   msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
   msgBox.setDefaultButton(QMessageBox::No);
-  msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
-  msgBox.setButtonText(QMessageBox::No, tr("No"));
+
   int ret = msgBox.exec();
   if (ret == QMessageBox::Yes) {
      stats->reset();
@@ -4375,8 +4374,6 @@ void MainWindow::on_pushButton_exit_clicked()
   msgBox.setInformativeText(tr("Are you sure?"));
   msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
   msgBox.setDefaultButton(QMessageBox::No);
-  msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
-  msgBox.setButtonText(QMessageBox::No, tr("No"));
 
   int ret = msgBox.exec();
   if (ret == QMessageBox::Yes) {


### PR DESCRIPTION
Fixes the following deprecation errors:
g++ -c -pipe -O2 -Wall -Wextra -mno-direct-extern-access -D_REENTRANT -DONLINE_PLAY -DUSE_LIBALLEGRO5 -DFULL_SCREEN -DDEBUG -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -I/usr/include/qt6 -I/usr/include/qt6/QtSvg -I/usr/include/qt6/QtWidgets -I/usr/include/qt6/QtGui -I/usr/include/qt6/QtNetwork -I/usr/include/qt6/QtCore -I. -I. -I/usr/lib64/qt6/mkspecs/linux-g++ -o mainwindow.o mainwindow.cpp mainwindow.cpp: In member function ‘void MainWindow::on_actionReset_triggered()’: mainwindow.cpp:2148:23: warning: ‘void QMessageBox::setButtonText(int, const QString&)’ is deprecated: Use addButton() instead. [-Wdeprecated-declarations]
 2148 |   msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
      |   ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt6/QtWidgets/QMessageBox:1,
                 from mainwindow.cpp:10:
/usr/include/qt6/QtWidgets/qmessagebox.h:274:10: note: declared here
  274 |     void setButtonText(int button, const QString &text);
      |          ^~~~~~~~~~~~~
mainwindow.cpp:2149:23: warning: ‘void QMessageBox::setButtonText(int, const QString&)’ is deprecated: Use addButton() instead. [-Wdeprecated-declarations]
 2149 |   msgBox.setButtonText(QMessageBox::No, tr("No"));
      |   ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtWidgets/qmessagebox.h:274:10: note: declared here
  274 |     void setButtonText(int button, const QString &text);
      |          ^~~~~~~~~~~~~
mainwindow.cpp: In member function ‘void MainWindow::on_pushButton_exit_clicked()’:
mainwindow.cpp:4378:23: warning: ‘void QMessageBox::setButtonText(int, const QString&)’ is deprecated: Use addButton() instead. [-Wdeprecated-declarations]
 4378 |   msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
      |   ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtWidgets/qmessagebox.h:274:10: note: declared here
  274 |     void setButtonText(int button, const QString &text);
      |          ^~~~~~~~~~~~~
mainwindow.cpp:4379:23: warning: ‘void QMessageBox::setButtonText(int, const QString&)’ is deprecated: Use addButton() instead. [-Wdeprecated-declarations]
 4379 |   msgBox.setButtonText(QMessageBox::No, tr("No"));
      |   ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtWidgets/qmessagebox.h:274:10: note: declared here
  274 |     void setButtonText(int button, const QString &text);
      |          ^~~~~~~~~~~~~